### PR TITLE
Platformsh detect deploy errors

### DIFF
--- a/.github/workflows/platformsh-deploy-test.yml
+++ b/.github/workflows/platformsh-deploy-test.yml
@@ -1,0 +1,13 @@
+name: 'Platform.sh - Successful deploy test'
+
+on: pull_request
+permissions: write-all
+
+jobs:
+  platformsh-deploy-test:
+    uses: reload/workflow-platformsh-deploy-status/.github/workflows/platformsh-deploy-test.yml@main
+    with:
+      PLATFORMSH_ID: ppobdkgor7fo6
+      DEPLOY_STATUS_URL_FILE: ./.platform-deploy-status-url
+    secrets:
+      PLATFORMSH_KEY: ${{ secrets.DAIS_PLATFORMSH_KEY }}

--- a/.platform-deploy-status-url
+++ b/.platform-deploy-status-url
@@ -1,0 +1,2 @@
+%site-url%/sites/default/files/deploy-status
+

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -107,13 +107,22 @@ hooks:
     (cd "$PLATFORM_DOCUMENT_ROOT/../" && npm install && npm run build)
     curl -sS https://platform.sh/cli/installer | php
 
-
   # We run deploy hook after your application has been deployed and started.
+  # We use set -e to cause a total fail if something goes wrong.
+  # Otherwise, a deploy-status file will instead be populated with 1.
+  # You can use a Github action to check if there was any issues with deploy.
+  # This is necessary, as PlatformSH just fails silently, such as when
+  # the Drupal config is invalid.
   deploy: |
+    STATUS_FILE="$PLATFORM_DOCUMENT_ROOT/sites/default/files/deploy-status"
+    rm -f "$STATUS_FILE"
+    echo "0" > "$STATUS_FILE"
+    set -e
     cd "$PLATFORM_DOCUMENT_ROOT"
     drush --yes deploy
     drush locale-import da modules/custom/storypal_base/translations/da.po
     drush --yes cache:rebuild
+    echo "1" > "$STATUS_FILE"
 
 # The configuration of scheduled execution.
 crons:


### PR DESCRIPTION
Detect if deploy to PSH failed.

- Adding a deploy-status file to our .platform.app.yaml deployer
- Adding a Github Action that notifies us if it has failed

We use set -e to cause a total fail if something goes wrong.
Otherwise, a deploy-status file will instead be populated with 1.
You can use a Github action to check if there was any issues with deploy.
This is necessary, as PlatformSH just fails silently, such as when
the Drupal config is invalid.