### PR TITLE
twig cache in storybook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   web:
-    image: reload/drupal-apache-fpm:latest
+    image: ghcr.io/reload/drupal-apache-fpm:latest
     ports:
       - '80'
       - '443'
@@ -18,7 +18,7 @@ services:
     working_dir: /var/www
 
   fpm:
-    image: reload/drupal-php7-fpm:7.4
+    image: ghcr.io/reload/docker-drupal-php7-fpm:7.4
     ports:
       - '9000'
     depends_on:

--- a/web/themes/custom/storypal_theme/.storybook/preview.js
+++ b/web/themes/custom/storypal_theme/.storybook/preview.js
@@ -11,6 +11,9 @@ import './drupal.js';
 
 import '../dist/js/storypal_theme.polyfills.js';
 
+//Remove twig cahche from storybook
+Twig.cache(false);
+
 // Add the filters to Twig instance.
 twigDrupal(Twig);
 


### PR DESCRIPTION
This PR updates the images for fpm / web in docker-compose. 

This PR removes the twig cache from storybook. 

- Updated fpm and web images, that have been moved to github
- Removed twig cache from storybook

# For the reviewer

## How-To-Test:

Run the project. Add style change to a twig template and see if changes are reflected in storybook without manual reload. 

